### PR TITLE
Fixed actor-status.html for spelling  error

### DIFF
--- a/templates/actor/parts/actor-status.html
+++ b/templates/actor/parts/actor-status.html
@@ -63,7 +63,7 @@
             </div>
             <div class="help-item">
                 <span class="symbol wounded"></span>
-                <p>Trated injury (Right Click)</p>
+                <p>Treated injury (Right Click)</p>
             </div>
             <div class="help-item">
                 <span class="symbol crippled"></span>


### PR DESCRIPTION
Update to the template file to fix a spelling mistake. Now shows as:

![image](https://user-images.githubusercontent.com/28914147/124837989-45f47000-dfc9-11eb-99c5-b0b24c700eb4.png)

as originally intended