### PR TITLE
Fixed actors not having valuables when first created

### DIFF
--- a/template.json
+++ b/template.json
@@ -215,7 +215,8 @@
         "base",
         "derived",
         "body",
-        "stats"
+        "stats",
+        "valuables"
       ]
     },
     "robot": {
@@ -223,19 +224,22 @@
         "base",
         "derived",
         "body",
-        "stats"
+        "stats",
+        "valuables"
       ]
     },
     "npc": {
       "templates": [
         "base",
         "derived",
-        "stats"
+        "stats",
+        "valuables"
       ]
     },
     "creature": {
       "templates": [
-        "base"
+        "base",
+        "valuables"
       ],
       "powerLevel": "normal",
       "body": {


### PR DESCRIPTION
Newly created actors do not have the `data.currency` populated in their data when first created.

Steps to reproduce the behavior:
1. Create a new actor through the console:
```js
Actor.implementation.create({ name: "New Actor", type: "character", img: "icons/svg/item-bag.svg" });
```
2. Run this in the console:
```js
game.actors.getName("New Actor").data.data.currency
```
3. Query returns `undefined`

I'm adding support for the Fallout system in the Item Piles module, but this causes the module to fail to transfer any currencies to/from piles of items and caps. This pull request fixes the issue.