### PR TITLE
v 10.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ package.json
 *.7z
 *.zip
 *.rar
+
+# For V11
+fallout-macros/
+skills/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
+v 10.1.3
+
+- removed the **max** Foundry version from the system so you can test it on Foundry V11
+- small modification to encumbrance so the system.carryWeight.base could be modified by Active Effects
+- robot carryWeight modifications from armor is now only taking the equipped and not-stashed parts in to acount
+
+
 v 10.1.2
 
 - Lowering **max** version from **11** back to **10** since there are some problems in Foundry 11
 - Small fix in weapons names (to show if weapon is damaged)
 - Adding images and additional info to the Favorite Weapons Box.
 - Small styling fixes on the character status tab
+
 
 v 10.1.1
 
@@ -14,9 +22,11 @@ v 10.1.1
 - Improved the styling of chat messages that detail item's properties
 - Added Português (Brasil) translation
 
+
 v 10.1.0
 
 - Added new Block for Body Parts with resistances and Injuries to the NPC and Creature sheets. Unfortunately there is no way for me to migrate previous data so the resistances and the injuries of NPCs and Creatures must be repopulated.
+
 
 v 10.0.9
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -51,7 +51,7 @@ export class FalloutActor extends Actor {
     if (this.type !== 'character') return
     this._calculateCharacterBodyResistance()
     // Encumbrance
-    this.system.carryWeight.base = (parseInt(this.system.attributes.str.value) * 10) + parseInt(game.settings.get('fallout', 'carryBase'))
+    this.system.carryWeight.base += (parseInt(this.system.attributes.str.value) * 10) + parseInt(game.settings.get('fallout', 'carryBase'))
     this.system.carryWeight.value = this.system.carryWeight.base + parseInt(this.system.carryWeight.mod)    
     this.system.carryWeight.total = this._getItemsTotalWeight()
     this.system.encumbranceLevel = 0
@@ -209,9 +209,11 @@ export class FalloutActor extends Actor {
     })
     let _robotArmorsCarryModifier = 0;
     for (let i of robotArmors) {
-      _robotArmorsCarryModifier += parseInt(i.system.carry)
+      if(i.system.equipped && !i.system.stashed){
+        _robotArmorsCarryModifier += parseInt(i.system.carry)
+      }
     }
-    this.system.carryWeight.base = parseInt(game.settings.get('fallout', 'carryBaseRobot')) + _robotArmorsCarryModifier;
+    this.system.carryWeight.base += parseInt(game.settings.get('fallout', 'carryBaseRobot')) + _robotArmorsCarryModifier;
     this.system.carryWeight.value = parseInt(this.system.carryWeight.base) + parseInt(this.system.carryWeight.mod)
     this.system.carryWeight.total = this._getItemsTotalWeight()
     this.system.encumbranceLevel = 0

--- a/system.json
+++ b/system.json
@@ -2,11 +2,10 @@
   "id": "fallout",
   "title": "Fallout 2d20",
   "description": "The unofficial Fallout 2d20 System for FoundryVTT",
-  "version": "10.1.2",
+  "version": "10.1.3",
   "compatibility": {
     "minimum": "10",
-    "verified": "10",
-    "maximum": "10"
+    "verified": "10"
   },
   "authors": [
     {
@@ -63,6 +62,6 @@
   "socket": true,
   "url": "https://github.com/superseva/fallout",
   "manifest": "https://github.com/superseva/fallout/releases/latest/download/system.json",
-  "download": "https://github.com/superseva/fallout/releases/download/v10.1.2/fallout.zip",
+  "download": "https://github.com/superseva/fallout/releases/download/v10.1.3/fallout.zip",
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
v 10.1.3

- removed the **max** Foundry version from the system so you can test it on Foundry V11
- small modification to encumbrance so the system.carryWeight.base could be modified by Active Effects
- robot carryWeight modifications from armor is now only taking the equipped and not-stashed parts in to account