### PR TITLE
Fix system.defense.value for actor

### DIFF
--- a/templates/actor/parts/actor-status.html
+++ b/templates/actor/parts/actor-status.html
@@ -11,7 +11,7 @@
             </div>
             <div class="flexrow resource-row align-mid">
                 <label class="resource-label">{{localize "FALLOUT.TEMPLATES.DEFENSE"}}</label>
-                <input class="num-short-2" type="number" name="system.defense.base" value="{{system.defense.base}}">
+                <input class="num-short-2" type="number" name="system.defense.value" value="{{system.defense.value}}">
             </div>
             <div class="flexrow resource-row align-mid">
                 <label class="resource-label">{{localize "FALLOUT.TEMPLATES.INITIATIVE"}}</label>


### PR DESCRIPTION
The key used for the actor for the defense is not correct.
It should be `system.defense.value` instead of `system.defense.base`, like creature & npc.

I checked, you never use the second one.

This causes problems if we use these keys in other modules